### PR TITLE
pre-commitフックのvitest watch mode問題を修正

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,8 @@ repos:
         entry: just check-quality-commit
         language: system
         pass_filenames: false
-      - id: just-test-all
-        name: just test-all
-        entry: just test-all
+      - id: just-test-all-ci
+        name: just test-all-ci
+        entry: just test-all-ci
         language: system
         pass_filenames: false

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "check": "pnpm run typecheck && pnpm run lint",
     "lint:check-and-fix": "pnpm run typecheck && pnpm run lint:fix && pnpm run format",
     "test": "vitest",
+    "test:run": "vitest run",
     "test:coverage": "vitest --coverage",
     "test:ui": "vitest --ui"
   },

--- a/justfile
+++ b/justfile
@@ -58,12 +58,19 @@ test-backend-cov:
 test-frontend:
 	cd {{frontend_dir}} && {{pnpm}} test
 
+# フロントエンドテスト実行（CI用、watch modeなし）
+test-frontend-ci:
+	cd {{frontend_dir}} && {{pnpm}} test:run
+
 # フロントエンドテスト実行（カバレッジ付き）
 test-frontend-cov:
 	cd {{frontend_dir}} && {{pnpm}} test:coverage
 
 # 全テスト実行（逐次実行、エラー時停止）
 test-all: test-backend test-frontend
+
+# 全テスト実行（CI用、watch modeなし）
+test-all-ci: test-backend test-frontend-ci
 
 # --- コード品質チェック ---
 


### PR DESCRIPTION
![PR-Header](https://capsule-render.vercel.app/api?type=slice&height=39&color=0:ffc800,100:33aaee&section=header&reversal=false)
## 課題へのリンク

- close #なし

## PRタイプ

- 💻開発ツール・プロセス

## 概要

- pre-commitフック実行時にvitestがwatch modeでブロックされる問題を解消。

## 対応内容・やったこと

- frontend/package.jsonにtest:runスクリプトを追加（vitest run）。
- justfileにtest-all-ciタスクを追加（CI用、watch modeなし）。
- .pre-commit-config.yamlをtest-allからtest-all-ciに変更。

### チェックリスト

- [ ] branch名はどんな作業を行ったかわかる命名にしたか(ex.feature/impl_login-page)
- [ ] マージ先のブランチは正しいか
- [ ] 影響確認を行ったか
- [ ] ローカルで起動確認は行ったか
- [ ] AIによるレビューの実施を行い、以下の確認をしたか
  - [ ] 指摘事項の妥当性の確認
  - [ ] 根拠の確認・調査
  - [ ] 指摘事項の修正
  - [ ] 再レビューの実施

## やってないこと

- なし

## 動作確認

- 未実施

## レビュワーへの注意点・相談内容・懸念点

- なし

![PR-Foorter](https://capsule-render.vercel.app/api?type=slice&height=39&color=0:ffc800,100:33aaee&section=footer&reversal=false)