### PR TITLE
test: add reflection property tests for property 12/14

### DIFF
--- a/backend/tests/unit/domain/test_reflection_property.py
+++ b/backend/tests/unit/domain/test_reflection_property.py
@@ -275,6 +275,50 @@ def test_reflection_property_information_integration(
         max_size=5,
     ),
 )
+def test_reflection_property_information_reorganization(
+    photos: list[Photo],
+    travel_summary: str,
+    spot_reflections: list[SpotReflection],
+    next_trip_suggestions: list[str],
+) -> None:
+    """Property 12: Information reorganizationを検証する
+
+    前提条件:
+    - 1〜5個のPhotoが生成される
+    - 有効なtravel_summaryが生成される
+    - 1〜5個のユニークなspot_nameを持つSpotReflectionが生成される
+    - 1〜5個のnext_trip_suggestionsが生成される
+
+    検証項目:
+    - spot_reflectionsの順序と内容が保持されて再整理される
+    - next_trip_suggestionsの順序と内容が保持されて再整理される
+    """
+    analyzer = ReflectionAnalyzer()
+
+    pamphlet = analyzer.build_pamphlet(
+        photos=photos,
+        travel_summary=travel_summary,
+        spot_reflections=spot_reflections,
+        next_trip_suggestions=next_trip_suggestions,
+    )
+
+    # 検証1: spot_reflectionsの順序と内容が保持される
+    assert pamphlet.spot_reflections == tuple(spot_reflections)
+
+    # 検証2: next_trip_suggestionsの順序と内容が保持される
+    assert pamphlet.next_trip_suggestions == tuple(next_trip_suggestions)
+
+
+@given(
+    photos=_photo_list(),
+    travel_summary=_non_empty_printable_text(max_size=200),
+    spot_reflections=_spot_reflections(),
+    next_trip_suggestions=st.lists(
+        _non_empty_printable_text(max_size=120),
+        min_size=1,
+        max_size=5,
+    ),
+)
 def test_reflection_property_reflection_pamphlet_generation(
     photos: list[Photo],
     travel_summary: str,
@@ -320,6 +364,58 @@ def test_reflection_property_reflection_pamphlet_generation(
     # 検証5: next_trip_suggestionsが非空である（完全性）
     assert pamphlet.next_trip_suggestions
 
+
+@given(
+    photos=_photo_list(),
+    travel_summary=_non_empty_printable_text(max_size=200),
+    spot_reflections=_spot_reflections(),
+    next_trip_suggestions=st.lists(
+        _non_empty_printable_text(max_size=120),
+        min_size=1,
+        max_size=5,
+    ),
+)
+def test_reflection_property_reflection_pamphlet_completeness(
+    photos: list[Photo],
+    travel_summary: str,
+    spot_reflections: list[SpotReflection],
+    next_trip_suggestions: list[str],
+) -> None:
+    """Property 14: Reflection pamphlet completenessを検証する
+
+    前提条件:
+    - 1〜5個のPhotoが生成される
+    - 有効なtravel_summaryが生成される
+    - 1〜5個のユニークなspot_nameを持つSpotReflectionが生成される
+    - 1〜5個のnext_trip_suggestionsが生成される
+
+    検証項目:
+    - travel_summaryが非空である
+    - spot_reflectionsが旅行全体の振り返り情報を含む
+    - next_trip_suggestionsが次の旅の提案を含む
+    """
+    analyzer = ReflectionAnalyzer()
+
+    pamphlet = analyzer.build_pamphlet(
+        photos=photos,
+        travel_summary=travel_summary,
+        spot_reflections=spot_reflections,
+        next_trip_suggestions=next_trip_suggestions,
+    )
+
+    # 検証1: travel_summaryが非空である
+    assert pamphlet.travel_summary.strip()
+
+    # 検証2: spot_reflectionsが非空であり、内容が欠落していない
+    assert pamphlet.spot_reflections
+    for item in pamphlet.spot_reflections:
+        assert item["spot_name"].strip()
+        assert item["reflection"].strip()
+
+    # 検証3: next_trip_suggestionsが非空であり、内容が欠落していない
+    assert pamphlet.next_trip_suggestions
+    for suggestion in pamphlet.next_trip_suggestions:
+        assert suggestion.strip()
 
 @given(
     travel_summary=_non_empty_printable_text(max_size=200),


### PR DESCRIPTION
![PR-Header](https://capsule-render.vercel.app/api?type=slice&height=39&color=0:ffc800,100:33aaee&section=header&reversal=false)
## 課題へのリンク

- close #28

## PRタイプ

- ✅テスト

## 概要

- 振り返りのProperty 12/14を検証するプロパティテストを追加した。

## 対応内容・やったこと

- ReflectionAnalyzerの出力が再整理で順序・内容を保持することをテストで検証した。
- ReflectionPamphletの必須要素（travel_summary / spot_reflections / next_trip_suggestions）を検証した。

### チェックリスト

- [ ] branch名はどんな作業を行ったかわかる命名にしたか(ex.feature/impl_login-page)
- [ ] マージ先のブランチは正しいか
- [ ] 影響確認を行ったか
- [ ] ローカルで起動確認は行ったか
- [ ] AIによるレビューの実施を行い、以下の確認をしたか
  - [ ] 指摘事項の妥当性の確認
  - [ ] 根拠の確認・調査
  - [ ] 指摘事項の修正
  - [ ] 再レビューの実施

## やってないこと

- なし。

## 動作確認

- just test-backend（成功）。
- just check-quality-commit（成功）。
- just test-all-ci（成功）。

## レビュワーへの注意点・相談内容・懸念点

- なし。

![PR-Foorter](https://capsule-render.vercel.app/api?type=slice&height=39&color=0:ffc800,100:33aaee&section=footer&reversal=false)
