### PR TITLE
feat: update generation status during generation

### DIFF
--- a/backend/app/application/use_cases/generate_reflection.py
+++ b/backend/app/application/use_cases/generate_reflection.py
@@ -15,6 +15,7 @@ from app.domain.travel_guide.exceptions import TravelGuideNotFoundError
 from app.domain.travel_guide.repository import ITravelGuideRepository
 from app.domain.travel_plan.exceptions import TravelPlanNotFoundError
 from app.domain.travel_plan.repository import ITravelPlanRepository
+from app.domain.travel_plan.value_objects import GenerationStatus
 
 _REFLECTION_PAMPHLET_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -249,70 +250,83 @@ class GenerateReflectionPamphletUseCase:
 
         reflection_dto = ReflectionDTO.from_entity(reflection)
 
-        prompt = _build_reflection_prompt(
-            destination=travel_plan.destination,
-            travel_title=travel_plan.title,
-            spot_names=[spot.name for spot in travel_plan.spots],
-            guide_overview=travel_guide.overview,
-            guide_timeline=[
-                {
-                    "year": event.year,
-                    "event": event.event,
-                    "significance": event.significance,
-                }
-                for event in travel_guide.timeline
-            ],
-            guide_spot_details=[
-                {
-                    "spotName": detail.spot_name,
-                    "historicalBackground": detail.historical_background,
-                    "highlights": list(detail.highlights),
-                    "historicalSignificance": detail.historical_significance,
-                }
-                for detail in travel_guide.spot_details
-            ],
-            guide_checkpoints=[
-                {
-                    "spotName": checkpoint.spot_name,
-                    "checkpoints": list(checkpoint.checkpoints),
-                    "historicalContext": checkpoint.historical_context,
-                }
-                for checkpoint in travel_guide.checkpoints
-            ],
-            photos=reflection_dto.photos,
-            user_notes=user_notes,
-        )
+        travel_plan.update_generation_statuses(reflection_status=GenerationStatus.PROCESSING)
+        self._plan_repository.save(travel_plan)
 
-        structured = await self._ai_service.generate_structured_data(
-            prompt=prompt,
-            response_schema=_REFLECTION_PAMPHLET_SCHEMA,
-            system_instruction=(
-                "レスポンスはJSONのみで、スキーマに厳密に一致させてください。"
-                "説明文などの文章は日本語で出力してください。"
-            ),
-        )
-        if not isinstance(structured, dict):
-            raise ValueError("structured response must be a dict.")
+        try:
+            prompt = _build_reflection_prompt(
+                destination=travel_plan.destination,
+                travel_title=travel_plan.title,
+                spot_names=[spot.name for spot in travel_plan.spots],
+                guide_overview=travel_guide.overview,
+                guide_timeline=[
+                    {
+                        "year": event.year,
+                        "event": event.event,
+                        "significance": event.significance,
+                    }
+                    for event in travel_guide.timeline
+                ],
+                guide_spot_details=[
+                    {
+                        "spotName": detail.spot_name,
+                        "historicalBackground": detail.historical_background,
+                        "highlights": list(detail.highlights),
+                        "historicalSignificance": detail.historical_significance,
+                    }
+                    for detail in travel_guide.spot_details
+                ],
+                guide_checkpoints=[
+                    {
+                        "spotName": checkpoint.spot_name,
+                        "checkpoints": list(checkpoint.checkpoints),
+                        "historicalContext": checkpoint.historical_context,
+                    }
+                    for checkpoint in travel_guide.checkpoints
+                ],
+                photos=reflection_dto.photos,
+                user_notes=user_notes,
+            )
 
-        travel_summary = _require_str(structured.get("travelSummary"), "travelSummary")
-        spot_reflection_items = _require_list(structured.get("spotReflections"), "spotReflections")
-        next_trip_items = _require_list(
-            structured.get("nextTripSuggestions"), "nextTripSuggestions"
-        )
+            structured = await self._ai_service.generate_structured_data(
+                prompt=prompt,
+                response_schema=_REFLECTION_PAMPHLET_SCHEMA,
+                system_instruction=(
+                    "レスポンスはJSONのみで、スキーマに厳密に一致させてください。"
+                    "説明文などの文章は日本語で出力してください。"
+                ),
+            )
+            if not isinstance(structured, dict):
+                raise ValueError("structured response must be a dict.")
 
-        plan_spot_names = {spot.name for spot in travel_plan.spots}
-        spot_reflections = _build_spot_reflections(spot_reflection_items, plan_spot_names)
-        next_trip_suggestions = _build_next_trip_suggestions(next_trip_items)
+            travel_summary = _require_str(structured.get("travelSummary"), "travelSummary")
+            spot_reflection_items = _require_list(
+                structured.get("spotReflections"), "spotReflections"
+            )
+            next_trip_items = _require_list(
+                structured.get("nextTripSuggestions"), "nextTripSuggestions"
+            )
 
-        pamphlet = self._analyzer.build_pamphlet(
-            photos=reflection.photos,
-            travel_summary=travel_summary,
-            spot_reflections=spot_reflections,
-            next_trip_suggestions=next_trip_suggestions,
-        )
+            plan_spot_names = {spot.name for spot in travel_plan.spots}
+            spot_reflections = _build_spot_reflections(spot_reflection_items, plan_spot_names)
+            next_trip_suggestions = _build_next_trip_suggestions(next_trip_items)
 
-        reflection.update_notes(user_notes)
-        saved_reflection = self._reflection_repository.save(reflection)
+            pamphlet = self._analyzer.build_pamphlet(
+                photos=reflection.photos,
+                travel_summary=travel_summary,
+                spot_reflections=spot_reflections,
+                next_trip_suggestions=next_trip_suggestions,
+            )
+
+            reflection.update_notes(user_notes)
+            saved_reflection = self._reflection_repository.save(reflection)
+        except Exception:
+            travel_plan.update_generation_statuses(reflection_status=GenerationStatus.FAILED)
+            self._plan_repository.save(travel_plan)
+            raise
+
+        travel_plan.update_generation_statuses(reflection_status=GenerationStatus.SUCCEEDED)
+        self._plan_repository.save(travel_plan)
 
         return ReflectionPamphletDTO.from_pamphlet(
             pamphlet,

--- a/backend/app/application/use_cases/generate_travel_guide.py
+++ b/backend/app/application/use_cases/generate_travel_guide.py
@@ -19,6 +19,7 @@ from app.domain.travel_guide.value_objects import (
 from app.domain.travel_plan.entity import TravelPlan
 from app.domain.travel_plan.exceptions import TravelPlanNotFoundError
 from app.domain.travel_plan.repository import ITravelPlanRepository
+from app.domain.travel_plan.value_objects import GenerationStatus
 
 _TRAVEL_GUIDE_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -322,59 +323,70 @@ class GenerateTravelGuideUseCase:
         if duplicate_spots:
             raise ValueError(f"duplicate spot names are not allowed: {sorted(duplicate_spots)}")
 
-        historical_prompt = _build_historical_info_prompt(travel_plan)
-        historical_info = await self._ai_service.generate_with_search(
-            prompt=historical_prompt,
-            system_instruction="Collect concise historical information using search results.",
-        )
-        if not historical_info or not historical_info.strip():
-            raise ValueError("historical_info must be a non-empty string.")
+        travel_plan.update_generation_statuses(guide_status=GenerationStatus.PROCESSING)
+        self._plan_repository.save(travel_plan)
 
-        guide_prompt = _build_travel_guide_prompt(travel_plan, historical_info)
-        structured = await self._ai_service.generate_structured_data(
-            prompt=guide_prompt,
-            response_schema=_TRAVEL_GUIDE_SCHEMA,
-            system_instruction=(
-                "Return JSON that exactly matches the response schema. "
-                "Use Japanese for narrative fields."
-            ),
-        )
-        if not isinstance(structured, dict):
-            raise ValueError("structured response must be a dict.")
-
-        overview = _require_str(structured.get("overview"), "overview")
-        timeline_items = _require_list(structured.get("timeline"), "timeline")
-        spot_detail_items = _require_list(structured.get("spotDetails"), "spotDetails")
-        checkpoint_items = _require_list(structured.get("checkpoints"), "checkpoints")
-        map_data_raw = _require_dict(structured.get("mapData"), "mapData")
-
-        plan_spot_name_set = set(plan_spot_names)
-        spot_details = _build_spot_details(spot_detail_items, plan_spot_name_set)
-        checkpoints = _build_checkpoints(checkpoint_items, plan_spot_name_set)
-        timeline = _build_timeline(timeline_items, plan_spot_name_set)
-        map_data = _build_map_data(map_data_raw)
-
-        generated_guide = self._composer.compose(
-            plan_id=travel_plan.id,
-            overview=overview,
-            timeline=timeline,
-            spot_details=spot_details,
-            checkpoints=checkpoints,
-            map_data=map_data,
-        )
-
-        existing = self._guide_repository.find_by_plan_id(travel_plan.id)
-        if existing is None:
-            saved_guide = self._guide_repository.save(generated_guide)
-        else:
-            existing.update_guide(
-                overview=generated_guide.overview,
-                timeline=generated_guide.timeline,
-                spot_details=generated_guide.spot_details,
-                checkpoints=generated_guide.checkpoints,
-                map_data=generated_guide.map_data,
+        try:
+            historical_prompt = _build_historical_info_prompt(travel_plan)
+            historical_info = await self._ai_service.generate_with_search(
+                prompt=historical_prompt,
+                system_instruction="Collect concise historical information using search results.",
             )
-            saved_guide = self._guide_repository.save(existing)
+            if not historical_info or not historical_info.strip():
+                raise ValueError("historical_info must be a non-empty string.")
+
+            guide_prompt = _build_travel_guide_prompt(travel_plan, historical_info)
+            structured = await self._ai_service.generate_structured_data(
+                prompt=guide_prompt,
+                response_schema=_TRAVEL_GUIDE_SCHEMA,
+                system_instruction=(
+                    "Return JSON that exactly matches the response schema. "
+                    "Use Japanese for narrative fields."
+                ),
+            )
+            if not isinstance(structured, dict):
+                raise ValueError("structured response must be a dict.")
+
+            overview = _require_str(structured.get("overview"), "overview")
+            timeline_items = _require_list(structured.get("timeline"), "timeline")
+            spot_detail_items = _require_list(structured.get("spotDetails"), "spotDetails")
+            checkpoint_items = _require_list(structured.get("checkpoints"), "checkpoints")
+            map_data_raw = _require_dict(structured.get("mapData"), "mapData")
+
+            plan_spot_name_set = set(plan_spot_names)
+            spot_details = _build_spot_details(spot_detail_items, plan_spot_name_set)
+            checkpoints = _build_checkpoints(checkpoint_items, plan_spot_name_set)
+            timeline = _build_timeline(timeline_items, plan_spot_name_set)
+            map_data = _build_map_data(map_data_raw)
+
+            generated_guide = self._composer.compose(
+                plan_id=travel_plan.id,
+                overview=overview,
+                timeline=timeline,
+                spot_details=spot_details,
+                checkpoints=checkpoints,
+                map_data=map_data,
+            )
+
+            existing = self._guide_repository.find_by_plan_id(travel_plan.id)
+            if existing is None:
+                saved_guide = self._guide_repository.save(generated_guide)
+            else:
+                existing.update_guide(
+                    overview=generated_guide.overview,
+                    timeline=generated_guide.timeline,
+                    spot_details=generated_guide.spot_details,
+                    checkpoints=generated_guide.checkpoints,
+                    map_data=generated_guide.map_data,
+                )
+                saved_guide = self._guide_repository.save(existing)
+        except Exception:
+            travel_plan.update_generation_statuses(guide_status=GenerationStatus.FAILED)
+            self._plan_repository.save(travel_plan)
+            raise
+
+        travel_plan.update_generation_statuses(guide_status=GenerationStatus.SUCCEEDED)
+        self._plan_repository.save(travel_plan)
 
         return TravelGuideDTO.from_entity(saved_guide)
 

--- a/backend/tests/unit/application/test_generate_reflection_pamphlet_use_case.py
+++ b/backend/tests/unit/application/test_generate_reflection_pamphlet_use_case.py
@@ -1,0 +1,145 @@
+"""ReflectionPamphlet生成ユースケースのテスト"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.application.ports.ai_service import IAIService
+from app.application.use_cases.generate_reflection import GenerateReflectionPamphletUseCase
+from app.domain.travel_plan.value_objects import GenerationStatus
+from app.infrastructure.repositories.reflection_repository import ReflectionRepository
+from app.infrastructure.repositories.travel_guide_repository import TravelGuideRepository
+from app.infrastructure.repositories.travel_plan_repository import TravelPlanRepository
+
+
+class FakeAIService(IAIService):
+    """テスト用のAIサービス"""
+
+    def __init__(self, structured_data: dict[str, Any] | list[Any]) -> None:
+        self.structured_data = structured_data
+
+    async def generate_text(
+        self,
+        prompt: str,
+        *,
+        system_instruction: str | None = None,
+        temperature: float | None = None,
+        max_output_tokens: int | None = None,
+    ) -> str:
+        raise NotImplementedError
+
+    async def generate_with_search(
+        self,
+        prompt: str,
+        *,
+        system_instruction: str | None = None,
+        temperature: float | None = None,
+        max_output_tokens: int | None = None,
+    ) -> str:
+        raise NotImplementedError
+
+    async def analyze_image(
+        self,
+        prompt: str,
+        image_uri: str,
+        *,
+        system_instruction: str | None = None,
+        temperature: float | None = None,
+        max_output_tokens: int | None = None,
+    ) -> str:
+        raise NotImplementedError
+
+    async def generate_structured_data(
+        self,
+        prompt: str,
+        response_schema: dict[str, Any],
+        *,
+        system_instruction: str | None = None,
+        temperature: float | None = None,
+        max_output_tokens: int | None = None,
+    ) -> dict[str, Any] | list[Any]:
+        return self.structured_data
+
+
+def _structured_reflection_payload() -> dict[str, Any]:
+    return {
+        "travelSummary": "歴史的な背景を学びながら巡る充実した旅でした。",
+        "spotReflections": [
+            {"spotName": "清水寺", "reflection": "舞台からの眺めが印象的だった。"},
+            {"spotName": "金閣寺", "reflection": "金色の輝きと庭園の調和が美しい。"},
+        ],
+        "nextTripSuggestions": ["奈良の古都を巡る旅", "鎌倉の寺社を巡る旅"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_generate_reflection_pamphlet_use_case_updates_status_succeeded(
+    db_session: Session,
+    sample_travel_plan,
+    sample_travel_guide,
+    sample_reflection,
+) -> None:
+    """前提条件: 旅行計画/旅行ガイド/振り返りが存在する。
+    実行: 振り返りパンフレットを生成する。
+    検証: 生成ステータスがsucceededになる。
+    """
+    plan_repository = TravelPlanRepository(db_session)
+    guide_repository = TravelGuideRepository(db_session)
+    reflection_repository = ReflectionRepository(db_session)
+    ai_service = FakeAIService(structured_data=_structured_reflection_payload())
+
+    use_case = GenerateReflectionPamphletUseCase(
+        plan_repository=plan_repository,
+        guide_repository=guide_repository,
+        reflection_repository=reflection_repository,
+        ai_service=ai_service,
+    )
+    dto = await use_case.execute(
+        plan_id=sample_travel_plan.id,
+        user_id=sample_travel_plan.user_id,
+        user_notes="旅の思い出をまとめた感想です。",
+    )
+
+    assert dto.plan_id == sample_travel_plan.id
+    assert dto.travel_summary
+
+    plan = plan_repository.find_by_id(sample_travel_plan.id)
+    assert plan is not None
+    assert plan.reflection_generation_status == GenerationStatus.SUCCEEDED
+
+
+@pytest.mark.asyncio
+async def test_generate_reflection_pamphlet_use_case_sets_failed_status_on_structured_error(
+    db_session: Session,
+    sample_travel_plan,
+    sample_travel_guide,
+    sample_reflection,
+) -> None:
+    """前提条件: 構造化データが不正。
+    実行: 振り返りパンフレットを生成する。
+    検証: 生成ステータスがfailedになる。
+    """
+    plan_repository = TravelPlanRepository(db_session)
+    guide_repository = TravelGuideRepository(db_session)
+    reflection_repository = ReflectionRepository(db_session)
+    ai_service = FakeAIService(structured_data=[])
+
+    use_case = GenerateReflectionPamphletUseCase(
+        plan_repository=plan_repository,
+        guide_repository=guide_repository,
+        reflection_repository=reflection_repository,
+        ai_service=ai_service,
+    )
+    with pytest.raises(ValueError):
+        await use_case.execute(
+            plan_id=sample_travel_plan.id,
+            user_id=sample_travel_plan.user_id,
+            user_notes="失敗ケースの感想。",
+        )
+
+    plan = plan_repository.find_by_id(sample_travel_plan.id)
+    assert plan is not None
+    assert plan.reflection_generation_status == GenerationStatus.FAILED

--- a/backend/tests/unit/application/test_generate_travel_guide_use_case.py
+++ b/backend/tests/unit/application/test_generate_travel_guide_use_case.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from app.application.ports.ai_service import IAIService
 from app.application.use_cases.generate_travel_guide import GenerateTravelGuideUseCase
 from app.domain.travel_plan.exceptions import TravelPlanNotFoundError
+from app.domain.travel_plan.value_objects import GenerationStatus
 from app.infrastructure.persistence.models import TravelPlanModel
 from app.infrastructure.repositories.travel_guide_repository import TravelGuideRepository
 from app.infrastructure.repositories.travel_plan_repository import TravelPlanRepository
@@ -157,6 +158,10 @@ async def test_generate_travel_guide_use_case_creates_guide(
     assert saved is not None
     assert saved.overview == dto.overview
 
+    plan = plan_repository.find_by_id(sample_travel_plan.id)
+    assert plan is not None
+    assert plan.guide_generation_status == GenerationStatus.SUCCEEDED
+
 
 @pytest.mark.asyncio
 async def test_generate_travel_guide_use_case_updates_existing_guide(
@@ -287,3 +292,7 @@ async def test_generate_travel_guide_use_case_rejects_non_dict_structured_respon
     )
     with pytest.raises(ValueError):
         await use_case.execute(plan_id=sample_travel_plan.id)
+
+    plan = plan_repository.find_by_id(sample_travel_plan.id)
+    assert plan is not None
+    assert plan.guide_generation_status == GenerationStatus.FAILED


### PR DESCRIPTION
![PR-Header](https://capsule-render.vercel.app/api?type=slice&height=39&color=0:ffc800,100:33aaee&section=header&reversal=false)
## 課題へのリンク

- close #125

## PRタイプ

- 🆕新機能
- ✅テスト

## 概要

- 生成フロー開始/成功/失敗でTravelPlanの生成ステータスを更新し、永続化するため。

## 対応内容・やったこと

- GenerateTravelGuideUseCaseでguide_generation_statusの更新と永続化を追加。
- GenerateReflectionPamphletUseCaseでreflection_generation_statusの更新と永続化を追加。
- 成功/失敗ケースのテストを追加/更新。

### チェックリスト

- [x] branch名はどんな作業を行ったかわかる命名にしたか(ex.feature/impl_login-page)
- [x] マージ先のブランチは正しいか
- [x] 影響確認を行ったか
- [ ] ローカルで起動確認は行ったか
- [x] AIによるレビューの実施を行い、以下の確認をしたか
  - [x] 指摘事項の妥当性の確認
  - [x] 根拠の確認・調査
  - [x] 指摘事項の修正
  - [x] 再レビューの実施

## やってないこと

- なし

## 動作確認

- just check-quality-commit
- just test-all-ci

## レビュワーへの注意点・相談内容・懸念点

- なし

![PR-Foorter](https://capsule-render.vercel.app/api?type=slice&height=39&color=0:ffc800,100:33aaee&section=footer&reversal=false)